### PR TITLE
Fix usage of deprecated API of Pandas

### DIFF
--- a/gutenTAG/addons/timeeval.py
+++ b/gutenTAG/addons/timeeval.py
@@ -73,10 +73,11 @@ class TimeEvalAddOn(BaseAddOn):
         })
 
     def finalize(self, ctx: AddOnFinalizeContext) -> None:
-        df = pd.DataFrame(columns=columns)
         # add metadata
+        metadata = []
         for ts_obj in ctx.get_data(self.key):
-            df = df.append(ts_obj["datasets"], ignore_index=True)
+            metadata += ts_obj["datasets"]
+        df = pd.DataFrame(metadata, columns=columns)
         self._set_global_vals(df)
         self.df = df
         if ctx.should_save and ctx.output_folder is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.0
-pandas>=1.3.0,<2.0.0
+numpy>=1.21.6
+pandas>=1.3.0
 scipy>=1.7.3
 scikit-learn>=1.0.0
 matplotlib>=3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.0
-pandas>=1.3.0
+pandas>=1.3.0,<2.0.0
 scipy>=1.7.3
 scikit-learn>=1.0.0
 matplotlib>=3.5.0


### PR DESCRIPTION
Pandas released a new major version (2.0.0) that removed some deprecated APIs that we still used. This PR fixes the API usage and increased the NumPy version to avoid a CVE!